### PR TITLE
Handling columns form form_calcs API client/server (user_id, preset)

### DIFF
--- a/server/src/db/formCalcPresets.yml
+++ b/server/src/db/formCalcPresets.yml
@@ -3,7 +3,7 @@
   json:
     name: Grim Reaper
     id: ckbzwhr4100473h5x419v8k5k
-    marchCap: '144000'
+    marchCap: '500000'
     tierDefs:
       - tierNum: T12
         capacity: '79085'

--- a/server/src/db/migrations/20200624230920_create_form_calcs.ts
+++ b/server/src/db/migrations/20200624230920_create_form_calcs.ts
@@ -8,7 +8,7 @@ export async function up(knex: Knex): Promise<any> {
       table.string('name').notNullable()
       table.string('description', 4096).notNullable().defaultTo('')
       table.json('json').notNullable().defaultTo('{}')
-      table.boolean('preset').defaultTo(false)
+      table.boolean('preset').defaultTo(false).notNullable()
       table
         .bigInteger('user_id')
         .unsigned()

--- a/server/src/db/seeds.ts
+++ b/server/src/db/seeds.ts
@@ -22,10 +22,10 @@ const Seeds:any = {
   seedData: {
     "User": [
       {
-        "name":"Sean Maxwell",
-        "email":"sean.maxwell@gmail.com",
+        "name":"regular user",
+        "email":"user@example.com",
         "password":"password", // password is "password"
-        "role":1
+        "role":0
       },
       {
         "name":"Admin",

--- a/server/src/models/FormCalc.ts
+++ b/server/src/models/FormCalc.ts
@@ -9,7 +9,7 @@ export default class FormCalc extends BaseModel implements IFormCalc {
   name!: string
   description!: string
   json!: string
-  user_id!: number
+  user_id!: number | null
   preset!: boolean
 
   // Table name is the only required property.

--- a/server/src/routes/FormCalcs.ts
+++ b/server/src/routes/FormCalcs.ts
@@ -43,6 +43,15 @@ router.post('/create', async (req: Request, res: Response) => {
   formCalc.json = req.body.json
   const user_id = res.locals.userId
   formCalc.user_id = user_id
+  const admin = res.locals.admin
+  if( admin ) {
+    formCalc.preset = req.body.preset && true
+    if( formCalc.preset ) {
+      formCalc.user_id = null
+    }
+  } else {
+    formCalc.preset = false
+  }
   try {
     formCalc.$validate()
   } catch (err) {
@@ -70,6 +79,15 @@ router.put('/update/:id', async (req: Request, res: Response) => {
   }
   if(formCalc.id) { formCalc.id = Number(formCalc.id) }
   if(formCalc.user_id) { formCalc.user_id = Number(formCalc.user_id) }
+  const admin = res.locals.admin
+  if( admin ) {
+    formCalc.preset = req.body.preset && true
+    if( formCalc.preset ) {
+      formCalc.user_id = null
+    }
+  } else {
+    formCalc.preset = false
+  }
   try {
     const rowsUpdated = await FormCalc.patch(Number(id), formCalc)
     return res.status(OK).json(rowsUpdated)

--- a/src/client_server/interfaces/FormCalc.ts
+++ b/src/client_server/interfaces/FormCalc.ts
@@ -4,7 +4,7 @@ export type FormCalc = {
   description: string
   json: string,
   preset: boolean,
-  user_id: number
+  user_id: number | null
 }
 
 export default FormCalc

--- a/src/features/form_calc/actions.ts
+++ b/src/features/form_calc/actions.ts
@@ -44,6 +44,11 @@ export const updateName = createAction('UPDATE_NAME', (id: string, value: string
   value: value
 }))<IdString>();
 
+export const updatePresetFlag = createAction('UPDATE_PRESET', (id: string, boolean: boolean) => ({
+  id: id,
+  boolean: boolean
+}))<IdBoolean>();
+
 export const updateTroopCount = createAction('UPDATE_TROOP_COUNT', (id: string, value: string) => ({
   id: id,
   value: value

--- a/src/features/form_calc/actions.ts
+++ b/src/features/form_calc/actions.ts
@@ -39,6 +39,8 @@ export const setFcId = createAction('SET_FC_ID', (id:string) => ({
   id: id
 }))<IdOnly>()
 
+export const clearCalculators = createAction('CLEAR_CALCULATORS', () => {})<void>()
+
 export const updateName = createAction('UPDATE_NAME', (id: string, value: string) => ({
   id: id,
   value: value

--- a/src/features/form_calc/components/CalculatorView.tsx
+++ b/src/features/form_calc/components/CalculatorView.tsx
@@ -8,18 +8,22 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import * as NumEntry from '../../../lib/num-entry';
 import * as actions from '../actions';
 import * as selectors from '../selectors';
+import * as usersSelector from '../../users/selectors'
+import { UserRoles } from '../../../client_server/interfaces/User'
 import { TierDefView } from './TierDefView';
 import config from '../../../config';
 import UndoRedo from './UndoRedo';
 
 const mapStateToProps = (state: RootState) => ({
-  formCalcs: selectors.getFormCalcs(state.formCalc)
+  currentUser: usersSelector.currentUser(state.users),
+  formCalcs: selectors.getFormCalcs(state.formCalc),
 });
 
 const dispatchProps = {
   resetState: actions.resetState,
   updateName: actions.updateName,
   updateMarchCap: actions.updateMarchCap,
+  updatePresetFlag: actions.updatePresetFlag,
   saveFormCalc: actions.saveFormCalc
 };
 
@@ -70,6 +74,18 @@ class CalculatorViewBase extends React.Component<Props, State> {
   data() {
     const formCalc = this.props.formCalcs[this.props.id];
     return formCalc;
+  }
+
+  isPreset() {
+    return this.data()?.preset
+  }
+
+  currentUser() {
+    return this.props.currentUser
+  }
+
+  isAdmin() {
+    return this.currentUser()?.role === UserRoles.Admin
   }
 
   hasModel() {
@@ -174,6 +190,29 @@ class CalculatorViewBase extends React.Component<Props, State> {
     )
   }
 
+  renderAdminRow() {
+    const admin = this.isAdmin()
+    console.log(`admin: ${admin}`)
+    const onClick = (e:any) => {
+      this.props.updatePresetFlag(this.props.id, !this.isPreset())
+    }
+    if( admin ) {
+      return (
+        <Row>
+          <Col>
+            <Form.Group>
+              <Form.Check
+                checked={this.data().preset}
+                label="Preset"
+                onClick={onClick}
+              />
+            </Form.Group>
+          </Col>
+        </Row>
+      )
+    } else { return (null) }
+  }
+
   render() {
     if( !this.data() ) {
       if( this.props.debug ) {
@@ -208,6 +247,7 @@ class CalculatorViewBase extends React.Component<Props, State> {
             <UndoRedo/>
           </Col>
         </Row>
+        {this.renderAdminRow()}
         {this.renderDebug()}
         <Row>
           <Col>

--- a/src/features/form_calc/models/MFormCalc.ts
+++ b/src/features/form_calc/models/MFormCalc.ts
@@ -119,6 +119,12 @@ class MFormCalc extends MBase {
     return this.objectForState();
   }
 
+  // Handles simple change to name
+  updatePresetFlagHandler(payload:IdBoolean) {
+    this.updatePresetFlag(payload.boolean)
+    return this.objectForState();
+  }
+
   // Handles change to main march cap.
   // should update entire formation based on new march cap
   updateMarchCapHandler(payload:IdString) {
@@ -350,6 +356,13 @@ class MFormCalc extends MBase {
     name = name.trim()
     if( this.name !== name ) {
       this.name = name
+      this.markForUpdate()
+    }
+  }
+
+  updatePresetFlag(preset:boolean) {
+    if( this.preset !== preset ) {
+      this.preset = preset
       this.markForUpdate()
     }
   }

--- a/src/features/form_calc/reducer.ts
+++ b/src/features/form_calc/reducer.ts
@@ -73,6 +73,9 @@ const _formCalcReducer = createReducer(BlankFCState)
       currentId: action.payload.id
     }
   })
+  .handleAction(actions.clearCalculators, (state, action) => {
+    return BlankFCState
+  })
   .handleAction(actions.updateName, (state, action) => {
     return fcReturnState(state, getFormationById(state, action.payload.id).updateNameHandler(action.payload));
   })

--- a/src/features/form_calc/reducer.ts
+++ b/src/features/form_calc/reducer.ts
@@ -76,6 +76,9 @@ const _formCalcReducer = createReducer(BlankFCState)
   .handleAction(actions.updateName, (state, action) => {
     return fcReturnState(state, getFormationById(state, action.payload.id).updateNameHandler(action.payload));
   })
+  .handleAction(actions.updatePresetFlag, (state, action) => {
+    return fcReturnState(state, getFormationById(state, action.payload.id).updatePresetFlagHandler(action.payload));
+  })
   .handleAction(actions.updateTroopCount, (state, action) => {
     return fcReturnState(state, getFormationById(state, action.payload.id).updateTroopCountHandler(action.payload));
   })

--- a/src/features/users/epics.ts
+++ b/src/features/users/epics.ts
@@ -5,6 +5,7 @@ import { RootAction, RootState, Services, isActionOf } from 'typesafe-actions';
 
 import { loginUserAsync, logoutUserAsync, createUserAsync } from './actions';
 import { showAlert } from '../modals/actions'
+import { clearCalculators } from '../form_calc/actions'
 import User from '../../client_server/interfaces/User'
 import { push } from 'connected-react-router'
 
@@ -21,6 +22,7 @@ export const loginUserEpic: Epic<
       from(api.users.loginUser(action.payload)).pipe(
         mergeMap((user:User) => of(
           showAlert('Login successful'),
+          clearCalculators(),
           loginUserAsync.success(user),
           push('/'),
         )),
@@ -42,7 +44,10 @@ export const logoutUserEpic: Epic<
     filter(isActionOf(logoutUserAsync.request)),
     switchMap((action) =>
       from(api.users.logoutUser()).pipe(
-        map(logoutUserAsync.success),
+        mergeMap(() => of(
+          clearCalculators(),
+          logoutUserAsync.success(),
+        )),
         catchError((message: string) => of(
           logoutUserAsync.failure(message.toString()),
           showAlert(message.toString(), {variant: 'danger'})

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,4 +1,12 @@
 import User from '../client_server/interfaces/User'
-export const currentUser = ():User|undefined => localStorage['currentUser']
-export const setCurrentUser = (user:User) => { localStorage['currentUser'] = user }
-export const clearCurrentUser = () => { delete localStorage['currentUser'] }
+export const currentUser = ():User|undefined => {
+  try {
+    return JSON.parse(localStorage['currentUser'])
+  } catch {
+    return undefined;
+  }
+}
+export const setCurrentUser = (user:User) => {
+  localStorage['currentUser'] = JSON.stringify(user)
+}
+export const clearCurrentUser = () => { localStorage.removeItem('currentUser') }

--- a/src/services/calcs-api-client.ts
+++ b/src/services/calcs-api-client.ts
@@ -36,7 +36,8 @@ const updateCalcEndpoint = '/api/form_calcs/update'
 export function update(formCalc:MFormCalc): Promise<MFormCalc> {
   const preparedBody = {
     name: formCalc.name,
-    json: formCalc.toJsonObject()
+    json: formCalc.toJsonObject(),
+    preset: formCalc.preset
   }
   return new Promise((resolve, reject) => {
     async function request(url = '', data = {}) {
@@ -48,8 +49,11 @@ export function update(formCalc:MFormCalc): Promise<MFormCalc> {
       })
       if( response.status === 200 )
         return response.json(); // parses JSON response into native JavaScript objects
-      else
-        throw `received status code ${response.status}`
+      else {
+        const json = await response.json()
+        throw `received status code ${response.status}\n`+json
+      }
+
     }
     const endPoint = `${updateCalcEndpoint}/${formCalc.id}`
     request(endPoint, preparedBody).then(
@@ -70,8 +74,10 @@ export function getUserCalcs(): Promise<[MFormCalc]> {
       })
       if( response.status === 200 )
         return response.json(); // parses JSON response into native JavaScript objects
-      else
-        throw `received status code ${response.status}`
+      else {
+        const json = await response.json()
+        throw `received status code ${response.status}\n`+json
+      }
     }
     request(getUserCalcsEndpoint).then(
       resp => resolve(resp.formCalcs.map((dbObj:any) => {

--- a/src/services/users-api-client.ts
+++ b/src/services/users-api-client.ts
@@ -28,7 +28,7 @@ export function loginUser(loginUser:LoginUser): Promise<User> {
     postData(authEndpoint, loginUser).then(
       resp => {
         console.log('loginUser resp: ', resp)
-        resolve(resp)
+        resolve(resp.user)
       }
     ).catch(error => reject(error))
   });

--- a/src/services/users-api-client.ts
+++ b/src/services/users-api-client.ts
@@ -55,8 +55,10 @@ export function logoutUser() {
       });
       if( response.status === 200 )
         return response
-      else
-        throw `received status code ${response.status}`
+      else {
+        const json = await response.json()
+        throw `received status code ${response.status}\n`+json
+      }
     }
     getData(logoutEndpoint).then(
       resp => {
@@ -91,8 +93,10 @@ export function createUser(createUser:CreateUser): Promise<CreateUser> {
       });
       if( response.status === 201 )
         return response.json() // parses JSON response into native JavaScript objects
-      else
-        throw `received status code ${response.status}`
+      else {
+        const json = await response.json()
+        throw `received status code ${response.status}\n`+json
+      }
     }
     postData(createUserEndpoint, {user: createUser}).then(
       resp => {


### PR DESCRIPTION
### Standardize handling `user_id` and `preset` columns in `form_calcs` table

#### SERVER
* Normalize/validate them on the server side in the request handlers
* Only admins can set the preset flag
* When `preset` flag is set and admin creates/updates an FC record, the `user_id` is set to NULL
* Added supporting specs

#### CLIENT
* show "preset" checkbox, only if  user is Admin on calculator view
* clear FormCalc Redux state when user logs in or out
* BUG fix in storing currentUser in localStorage
* Better error reporting in APIs